### PR TITLE
batadv: fix mesh-vpn interface name comparison

### DIFF
--- a/src/batadv.c
+++ b/src/batadv.c
@@ -82,7 +82,7 @@ static int parse_orig_list_netlink_cb(struct nl_msg *msg, void *arg)
 		return NL_OK;
 
 	opts->stats->neighbor_count++;
-	if (!strncmp(ifname, "mesh-vpn", strlen(ifname))) {
+	if (!strncmp(ifname, "mesh-vpn", sizeof("mesh-vpn"))) {
 		opts->stats->vpn.tq = nla_get_u8(attrs[BATADV_ATTR_TQ]);
 		opts->stats->vpn.connected = 1;
 	}


### PR DESCRIPTION
strcmp only compared the first strlen(ifname) characters, so any interface with a prefix of "mesh-vpn" (e.g. "mesh") incorrectly matched.

Using sizeof("mesh-vpn")<IF_NAMESIZE as the bound to include the null terminator in the comparison, ensuring an exact match without assuming ifname is null-terminated.