### PR TITLE
Build node-monitor alongside node-whisperer

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,9 @@ CFLAGS:=$(CFLAGS_nl) $(CFLAGS_batadv) $(CFLAGS_json)
 LDFLAGS_MONITOR:=$(LDFLAGS_genl) -DBUILD_MONITOR
 CFLAGS_MONITOR:=$(CFLAGS_genl)
 
-all:
+all: node-whisperer node-monitor
+
+node-whisperer:
 	$(CC) $(CFLAGS) -D_GNU_SOURCE -o node-whisperer daemon.c util.c information.c log.c ubus.c interface.c batadv.c $(LDFLAGS)
 
 node-monitor:

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc
 CFLAGS_common ?= -Wall -Wextra -Werror -std=c99 -g
-LDFLAGS_common ?= 
+LDFLAGS_common ?=
 
 PKG_CONFIG ?= pkg-config
 
@@ -34,5 +34,5 @@ CFLAGS_MONITOR:=$(CFLAGS_genl)
 all:
 	$(CC) $(CFLAGS) -D_GNU_SOURCE -o node-whisperer daemon.c util.c information.c log.c ubus.c interface.c batadv.c $(LDFLAGS)
 
-monitor:
-	$(CC) $(CFLAGS_MONITOR) -D_GNU_SOURCE -o monitor monitor.c log.c util.c ieee80211.c information.c $(LDFLAGS_MONITOR) 
+node-monitor:
+	$(CC) $(CFLAGS_MONITOR) -D_GNU_SOURCE -o node-monitor monitor.c log.c util.c ieee80211.c information.c $(LDFLAGS_MONITOR)

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -213,7 +213,7 @@ int nl_get_multicast_id(struct nl80211_sock *sock, const char *family, const cha
 	nl_cb_set(cb, NL_CB_ACK, NL_CB_CUSTOM, ack_handler, &ret);
 	nl_cb_set(cb, NL_CB_VALID, NL_CB_CUSTOM, family_handler, &grp);
 
-	ret = nl_send_auto(sock->nls, msg);
+	ret = nl_send_auto_complete(sock->nls, msg);
 	if (ret < 0) {
 		log_debug("nl_send_auto_complete() returned %d (%s).", ret, nl_geterror(-ret));
 		goto nla_put_failure;
@@ -290,7 +290,7 @@ int nl80211_trigger_scan(struct nl80211_sock *wifi, int ifindex)
 	nl_cb_set(cb, NL_CB_ACK, NL_CB_CUSTOM, ack_handler, &err);
 	nl_cb_set(cb, NL_CB_SEQ_CHECK, NL_CB_CUSTOM, no_seq_check, NULL);
 
-	nl_send_auto(wifi->nls, msg);
+	nl_send_auto_complete(wifi->nls, msg);
 
 	while (err > 0)
 		ret = nl_recvmsgs(wifi->nls, cb);
@@ -536,9 +536,9 @@ int nl80211_get_scan_results(struct nl80211_sock *wifi, int ifindex)
 		goto out_free;
 	}
 
-	ret = nl_send_auto(wifi->nls, msg);
+	ret = nl_send_auto_complete(wifi->nls, msg);
 	if (ret < 0) {
-		log_error("nl_send_auto() returned %d (%s).", ret, nl_geterror(-ret));
+		log_error("nl_send_auto_complete() returned %d (%s).", ret, nl_geterror(-ret));
 		goto out_free;
 	}
 


### PR DESCRIPTION
This adds the node-monitor to always build alongside node-whisperer. 

Adding this also makes sure it is being built as part of the CI.