### PR TITLE
fix: include sysinfo.h to fix modern musl builds

### DIFF
--- a/src/information.c
+++ b/src/information.c
@@ -6,8 +6,7 @@
 #include <stddef.h>
 
 #include <arpa/inet.h>
-#include <linux/unistd.h>
-#include <linux/kernel.h>
+#include <sys/sysinfo.h>
 
 #include "batadv.h"
 #include "util.h"


### PR DESCRIPTION
This should fix #3 