### PR TITLE
monitor: ignore short non-gluon vendor IEs without logging an error

### DIFF
--- a/src/monitor.c
+++ b/src/monitor.c
@@ -360,8 +360,9 @@ static int monitor_gluon_node_parse_ie(const uint8_t *ie, size_t ie_len, void *d
 		return 0;
 	}
 
-	if (ie_len < 6 + 3) {
-		log_error("IE is too short.");
+	/* Need header + OUI + vendor type before inspecting vendor-specific fields */
+	if (ie_len < 6) {
+		log_debug("Vendor IE too short to inspect OUI.");
 		return 0;
 	}
 
@@ -372,6 +373,11 @@ static int monitor_gluon_node_parse_ie(const uint8_t *ie, size_t ie_len, void *d
 
 	if (ie[5] != 0x04) {
 		log_debug("IE is not a gluon node IE.");
+		return 0;
+	}
+
+	if (ie_len < 6 + 3) {
+		log_error("Gluon node IE is too short.");
 		return 0;
 	}
 


### PR DESCRIPTION
The IE parser checked ie_len < 9 and log_error()'d "IE is too short." before validating the OUI, so any third-party vendor-specific IE (tag 0xdd) shorter than 9 bytes was logged as an error even though it was never destined for us. WiFi scans routinely showed such IEs from other devices.

Validate only the 6 bytes needed for the OUI/type compare first, then re-check the full length after the IE is confirmed to be a gluon node IE so a genuinely truncated one is still logged as an error.